### PR TITLE
ci: use new github actions cache backend to cache docker layers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,23 +79,12 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          version: v0.6.0-rc1
+          driver-opts: image=moby/buildkit:v0.9.0-rc2
       - name: Build
         uses: docker/build-push-action@v2
         with:
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,4 +87,4 @@ jobs:
         with:
           push: false
           cache-from: type=gha
-          cache-to: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           cache-from: type=gha
-          cache-to: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             git_sha=${{github.sha}}
             git_ref=${{github.ref}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,13 +91,9 @@ jobs:
             type=sha
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          version: v0.6.0-rc1
+          driver-opts: image=moby/buildkit:v0.9.0-rc2
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -108,18 +104,11 @@ jobs:
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha
           build-args: |
             git_sha=${{github.sha}}
             git_ref=${{github.ref}}
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   semantic-release:
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' }}
     name: Create a semantic release


### PR DESCRIPTION
Use the new github actions cache backend to cache docker layers, configured as specified in this pull request comment: https://github.com/docker/build-push-action/pull/406#issuecomment-879184394. The backend is still experimental but should already work. This solutions is more elegant and could be faster than the previous approach.