### PR TITLE
feat: allow relative path to servers

### DIFF
--- a/backend/settings.properties
+++ b/backend/settings.properties
@@ -1,1 +1,1 @@
-server-path=/usr/games/blockcluster/servers
+server-path=servers

--- a/backend/src/backend.ts
+++ b/backend/src/backend.ts
@@ -69,9 +69,13 @@ const backend = app.listen(port, () =>
 /**
  * The base path for the servers.
  */
-export const basePath: string = PropertiesReader("./settings.properties")
-  .get("server-path")
-  .toString();
+export const basePath: string = ((): string => {
+  const basePath = PropertiesReader("./settings.properties")
+    .get("server-path")
+    .toString();
+  if (path.isAbsolute(basePath)) return basePath;
+  return path.join(__dirname, "../../../..", basePath);
+})();
 
 /**
  * Returns a promise for an array of {@link Server}s based on base directory from `settings.properties`.


### PR DESCRIPTION
Allow `settings.properties`'s property `server-path` to hold a path relative to the blockcluster base directory.