### PR TITLE
feat: read server path from environment variable

### DIFF
--- a/backend/src/backend.ts
+++ b/backend/src/backend.ts
@@ -70,9 +70,11 @@ const backend = app.listen(port, () =>
  * The base path for the servers.
  */
 export const basePath: string = ((): string => {
-  const basePath = PropertiesReader("./settings.properties")
-    .get("server-path")
-    .toString();
+  let basePath: string = process.env.SERVER_PATH;
+  if (!basePath)
+    basePath = PropertiesReader("./settings.properties")
+      .get("server-path")
+      .toString();
   if (path.isAbsolute(basePath)) return basePath;
   return path.join(__dirname, "../../../..", basePath);
 })();


### PR DESCRIPTION
Read the minecraft server path from the environment variable `SERVER_PATH` if available. Otherwise the property `server-path` in `settings.properties` is used as before.