### PR TITLE
refactor: don't include `settings.properties` by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ FROM base-${ENVIRONMENT}
 COPY backend/package*.json ./backend/
 RUN cd backend && npm install --only=prod
 
-COPY backend/settings.properties backend/settings.properties
 COPY --from=builder /usr/games/blockcluster/dist dist
 COPY --from=builder /usr/games/blockcluster/backend/dist backend/dist
 COPY --from=builder /usr/games/blockcluster/.env ./

--- a/backend/settings.properties
+++ b/backend/settings.properties
@@ -1,1 +1,0 @@
-server-path=servers

--- a/backend/src/backend.ts
+++ b/backend/src/backend.ts
@@ -72,9 +72,14 @@ const backend = app.listen(port, () =>
 export const basePath: string = ((): string => {
   let basePath: string = process.env.SERVER_PATH;
   if (!basePath)
-    basePath = PropertiesReader("./settings.properties")
-      .get("server-path")
-      .toString();
+    try {
+      basePath = PropertiesReader("./settings.properties")
+        .get("server-path")
+        .toString();
+    } catch (error) {
+      basePath = "servers";
+    }
+
   if (path.isAbsolute(basePath)) return basePath;
   return path.join(__dirname, "../../../..", basePath);
 })();


### PR DESCRIPTION
Don't include `settings.properties` file by default anymore in the project. The default directory `servers` for the `server-path` is now stored in the code itself and used if the `settings.properties` file does not exist or `server-path` is not defined.