### PR TITLE
docs: state more precisely how to set the server path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Prerequisites:
 - Java (to run the minecraft servers)
 
 1. First build the app using the instructions from ["Building manually"](#building-manually).
-2. Create the `servers/` subdirectory and move your servers into it.
+2. Either
+   - create the `servers/` subdirectory and move your servers into it or
+   - set the environment variable `SERVER_PATH` to the relative or absolute path of your servers.
 3. Run `npm run start` and open `http://[your ip]:8081` in your browser.
 
 

--- a/backend/src/backend.ts
+++ b/backend/src/backend.ts
@@ -67,7 +67,11 @@ const backend = app.listen(port, () =>
 );
 
 /**
- * The base path for the servers.
+ * The base path for the minecraft servers.
+ *
+ * The minecraft server path is read from the environment variable `SERVER_PATH` if available. Otherwise the property `server-path` in file `settings.properties` is used.
+ *
+ * By default its value is the directory `servers/` relative to the root directory of blockcluster.
  */
 export const basePath: string = ((): string => {
   let basePath: string = process.env.SERVER_PATH;


### PR DESCRIPTION
State more precisely that the server path (relative or absolute) can be set using the environment variable `SERVER_PATH` and that the default value is the directory `servers/` relative to the blockcluster root directory. Using `settings.properties` is deprecated and the option will be removed in `v1.0.0` and is therefore not mentioned in `README.md`.