### PR TITLE
fix: use `umask 0000` only when `umask` is available

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,12 @@
         "@types/node": "*"
       }
     },
+    "@types/command-exists": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.0.tgz",
+      "integrity": "sha512-ugsxEJfsCuqMLSuCD4PIJkp5Uk2z6TCMRCgYVuhRo5cYQY3+1xXTQkSlPtkpGHuvWMjS2KTeVQXxkXRACMbM6A==",
+      "dev": true
+    },
     "@types/component-emitter": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
@@ -389,6 +395,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
     },
     "component-emitter": {
       "version": "1.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "start": "nodemon dist/backend/src/backend.js"
   },
   "devDependencies": {
+    "@types/command-exists": "^1.2.0",
     "@types/express": "^4.17.1",
     "@types/pidusage": "^2.0.1",
     "@types/properties-reader": "^2.1.0",
@@ -17,6 +18,7 @@
     "nodemon": "^2.0.9"
   },
   "dependencies": {
+    "command-exists": "^1.2.9",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
     "express": "^4.17.1",

--- a/backend/src/components/server.ts
+++ b/backend/src/components/server.ts
@@ -33,6 +33,7 @@ import fs from "fs";
 import Message, { MessageType } from "../../../common/components/message";
 import ServerConfig from "./server_config";
 import pidusage from "pidusage";
+import commandExists from "command-exists";
 import ResourceUsage from "../../../common/components/resource_usage";
 
 /**
@@ -265,8 +266,11 @@ export default class Server extends CommonServer {
    */
   public async start() {
     this.status = ServerStatus.Starting;
+    const permissionPrefix = commandExists.sync("umask")
+      ? "umask 0000 && "
+      : "";
     this.proc = spawn(
-      "umask 0000 && java",
+      permissionPrefix + "java",
       this.flags.concat(["-jar", this.getJarFile()]),
       {
         cwd: this.getPath(),


### PR DESCRIPTION
Running `umask` even if it is not available, lead to not being able to start minecraft servers in some environments e.g. on windows systems directly. This should not affect any behaviour of blockcluster systems running on docker images based on the official `Dockerfile`.