### PR TITLE
fix: use `nogui` option

### DIFF
--- a/backend/src/components/server.ts
+++ b/backend/src/components/server.ts
@@ -271,7 +271,7 @@ export default class Server extends CommonServer {
       : "";
     this.proc = spawn(
       permissionPrefix + "java",
-      this.flags.concat(["-jar", this.getJarFile()]),
+      this.flags.concat(["-jar", this.getJarFile(), "nogui"]),
       {
         cwd: this.getPath(),
         shell: true,


### PR DESCRIPTION
Use `nogui` option to disable the graphical user interface on some minecraft server flavors. This was especially needed when running blockcluster on windows directly, as the GUI would open up, when starting a minecraft server from within blockcluster, which is unintended behaviour.