### PR TITLE
feat: allow multiple java versions to be installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,21 @@ RUN npm run build
 COPY backend ./backend/
 RUN cd backend && tsc
 
-FROM openjdk:16-alpine AS jdk
+FROM openjdk:16-alpine AS jdk-16
 RUN jlink --output /opt/jre-16 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
+
+FROM alpine:3.13 AS jdk-11
+RUN apk --no-cache add openjdk11
+RUN /usr/lib/jvm/java-11-openjdk/bin/jlink --output /opt/jre-11 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
 
 FROM alpine:3.13 AS base
 RUN apk --no-cache add curl
 RUN apk add --no-cache java-cacerts
 ENV JAVA_HOME=/opt/java
 ENV PATH=/opt/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-COPY --from=jdk /opt/jre-16 /opt/java
+COPY --from=jdk-16 /opt/jre-16 /opt/java-16
+COPY --from=jdk-11 /opt/jre-11 /opt/java-11
+RUN ln -s /opt/java-16 /opt/java
 RUN apk add --update nodejs npm
 COPY LICENSE README.md ./
 # Set working directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,8 @@ RUN cd backend && tsc
 FROM eclipse-temurin:17-alpine AS jdk-17
 RUN /opt/java/openjdk/bin/jlink --output /opt/jre-17 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
 
-FROM alpine:3.13 AS jdk-11
-RUN apk --no-cache add openjdk11
-RUN /usr/lib/jvm/java-11-openjdk/bin/jlink --output /opt/jre-11 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
+FROM eclipse-temurin:11-alpine AS jdk-11
+RUN /opt/java/openjdk/bin/jlink --output /opt/jre-11 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
 
 FROM alpine:3.13 AS base
 RUN apk --no-cache add curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,15 @@ RUN npm run build
 COPY backend ./backend/
 RUN cd backend && tsc
 
-FROM openjdk:15-alpine AS jdk
-RUN jlink --output /opt/jre-15-ea --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
+FROM openjdk:16-alpine AS jdk
+RUN jlink --output /opt/jre-16 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
 
 FROM alpine:3.13 AS base
 RUN apk --no-cache add curl
 RUN apk add --no-cache java-cacerts
 ENV JAVA_HOME=/opt/java
 ENV PATH=/opt/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-COPY --from=jdk /opt/jre-15-ea /opt/java
+COPY --from=jdk /opt/jre-16 /opt/java
 RUN apk add --update nodejs npm
 COPY LICENSE README.md ./
 # Set working directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN npm run build
 COPY backend ./backend/
 RUN cd backend && tsc
 
-FROM openjdk:16-alpine AS jdk-16
-RUN jlink --output /opt/jre-16 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
+FROM eclipse-temurin:17-alpine AS jdk-17
+RUN /opt/java/openjdk/bin/jlink --output /opt/jre-17 --compress=2 --no-header-files --no-man-pages --module-path ../jmods --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.unsupported,jdk.zipfs
 
 FROM alpine:3.13 AS jdk-11
 RUN apk --no-cache add openjdk11
@@ -39,9 +39,9 @@ RUN apk --no-cache add curl
 RUN apk add --no-cache java-cacerts
 ENV JAVA_HOME=/opt/java
 ENV PATH=/opt/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-COPY --from=jdk-16 /opt/jre-16 /opt/java-16
+COPY --from=jdk-17 /opt/jre-17 /opt/java-17
 COPY --from=jdk-11 /opt/jre-11 /opt/java-11
-RUN ln -s /opt/java-16 /opt/java
+RUN ln -s /opt/java-17 /opt/java
 RUN apk add --update nodejs npm
 COPY LICENSE README.md ./
 # Set working directory.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An in-browser manager for your minecraft servers.
 - View current status
 - Show resource usage
 - View console log and send commands
+- Select different java runtimes (See also: ["Adding custom java runtimes"](#adding-custom-java-runtimes))
 - Change start flags
 - Start servers with backend
 
@@ -63,6 +64,35 @@ Prerequisites:
    - set the environment variable `SERVER_PATH` to the relative or absolute path of your servers.
 3. Run `npm run start` and open `http://[your ip]:8081` in your browser.
 
+### Adding custom java runtimes
+By default, the docker image based on [`docker-compose.yml`](docker-compose.yml) and the [`Dockerfile`](Dockerfile) includes java 11 and java 17. Those are the most relevant LTS java version for running minecraft servers (see [#150](https://github.com/jojomatik/blockcluster/issues/150) for more details).
+
+#### Windows
+All java runtimes in the `PATH` environment variable will be discovered and presented as an option in the frontend.
+
+#### Docker
+Mount additional java runtimes in the `/opt/java-xx` directory.
+
+With the `docker run` command:
+```sh
+docker run -d -v /path/to/servers/on/host/machine:/usr/games/blockcluster/servers -v /path/to/java-xx/on/host/machine:/opt/java-xx -p 8081:8081 25565-25569:25565-25569 jojomatik/blockcluster:latest
+```
+or with `docker-compose`
+```
+version: "3.9"
+services:
+  manager:
+    ports:
+      - 8081:8081
+      - 25565:25565
+    image: jojomatik/blockcluster
+    volumes:
+      - /path/to/servers/on/host/machine:/usr/games/blockcluster/servers
+      - /path/to/java-xx/on/host/machine:/opt/java-xx
+```
+```sh
+docker-compose up
+```
 
 ## Building
 ### Building with `docker-compose` (recommended)

--- a/backend/src/backend.ts
+++ b/backend/src/backend.ts
@@ -31,6 +31,7 @@ dotenvExpand(dotenv.config({ path: "../.env" }));
 dotenvExpand(dotenv.config({ path: "../.env.local" }));
 
 import { getVersion } from "../../common/version";
+import { getJavaRuntimes } from "./components/java_runtime";
 
 const app = express();
 
@@ -131,6 +132,11 @@ getServers().then((servers) => {
         await Promise.all(servers.map(async (server) => await server.update()));
         io.emit("MESSAGE", Server.strip(servers));
       }
+    });
+
+    // Respond with the available java runtimes when a message is received on `JAVA_RUNTIMES`.
+    socket.on("JAVA_RUNTIMES", () => {
+      io.emit("JAVA_RUNTIMES", getJavaRuntimes());
     });
 
     // Listen to a channel per server

--- a/backend/src/components/java_runtime.ts
+++ b/backend/src/components/java_runtime.ts
@@ -1,0 +1,129 @@
+/*
+blockcluster - An in-browser manager for your minecraft servers.
+Copyright (C) 2021 jojomatik
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import fs from "fs";
+import { spawnSync } from "child_process";
+import JavaRuntime from "../../../common/components/java_runtime";
+import commandExists from "command-exists";
+
+/**
+ * The directory that contains all java installations in the official docker build.
+ */
+const optDir = "/opt";
+
+/**
+ * The name of the `bin`-directory inside the java runtime directory.
+ */
+const bin = "bin";
+
+/**
+ * The name of the `java`-command inside the `bin` directory.
+ */
+const java = "java";
+
+/**
+ * The name of the `which` command used to retrieve the path of a program under linux.
+ */
+const which = "which";
+
+/**
+ * The name of the `where` command used to retrieve the path of a program under windows.
+ */
+const where = "where";
+
+/**
+ * Returns whether a path is a java runtime directory by checking for the `bin/java`-program inside the directory.
+ * @param path the path that should be checked.
+ */
+function isJavaDir(path: string): boolean {
+  const isDir: boolean = fs.lstatSync(path).isDirectory();
+  const hasBin = fs.readdirSync(path).includes(bin);
+  const hasJava: boolean = fs
+    .readdirSync(path + "/" + bin)
+    .map((file) => file.substr(0, 4)) // ignore file type
+    .includes(java);
+  return isDir && hasBin && hasJava;
+}
+
+/**
+ * Returns a {@link JavaRuntime} object for a path.
+ * @param path the path to the root of the java runtime.
+ */
+function getRuntime(path: string): JavaRuntime {
+  const command = spawnSync(path + "/" + bin + "/" + java, ["-version"]);
+  const name = command.stderr.toString().split("\n")[1];
+  return new JavaRuntime(path, name);
+}
+
+/**
+ * Returns a list of all discoverable {@link JavaRuntime}s.
+ *
+ * Uses the `where`-/ `which`-command to retrieve all/ the primary runtime in the `PATH` environment variable and resolves symbolic links if necessary. The first runtime listed will be used as the default runtime.
+ *
+ * Searches the `/opt` directory for further java runtimes.
+ */
+export function getJavaRuntimes(): JavaRuntime[] {
+  const runtimes: JavaRuntime[] = [];
+
+  // Get available `where`-/ `which`-command.
+  let cmd;
+  if (commandExists.sync(where)) {
+    cmd = spawnSync(where, [java]);
+  } else if (commandExists.sync(which)) {
+    cmd = spawnSync(which, [java]);
+  }
+
+  const checkedPaths: string[] = [];
+
+  if (cmd !== undefined) {
+    // Get `java` runtimes found by `where`-/ `which`-command.
+    const paths: string[] = cmd.stdout.toString().split("\n");
+    // Remove empty line.
+    paths.pop();
+    for (let path of paths) {
+      // Get root directory of java runtime.
+      path = path.replace(
+        new RegExp(/[\\/]bin[\\/]java(?:.[a-z]{1,3}\r?)?$/),
+        ""
+      );
+      // Resolve symbolic links.
+      while (fs.lstatSync(path).isSymbolicLink()) path = fs.readlinkSync(path);
+
+      // Check if directory is a java runtime and add to list.
+      if (!checkedPaths.includes(path)) {
+        checkedPaths.push(path);
+        if (isJavaDir(path)) {
+          const runtime: JavaRuntime = getRuntime(path);
+          if (runtimes.length === 0) runtime.isDefault = true;
+          runtimes.push(runtime);
+        }
+      }
+    }
+  }
+
+  // Scan `/opt` directory for java runtimes.
+  if (fs.existsSync(optDir))
+    for (const file of fs.readdirSync(optDir)) {
+      const path = optDir + "/" + file;
+      if (!checkedPaths.includes(path) && isJavaDir(path)) {
+        runtimes.push(getRuntime(path));
+      }
+    }
+
+  return runtimes;
+}

--- a/backend/src/components/server.ts
+++ b/backend/src/components/server.ts
@@ -71,6 +71,7 @@ export default class Server extends CommonServer {
     await this.updateStatus();
     this.jar = this.getJarFile();
     this.config = await this.readConfig();
+    this.javaPath = this.getJavaPath();
     this.flags = await this.getFlags();
     this.autostart = this.config.autostart;
   }
@@ -152,6 +153,10 @@ export default class Server extends CommonServer {
                 this.autostart = data[key];
                 await this.writeConfig();
                 break;
+              case "javaRuntime":
+                this.javaPath = data[key];
+                await this.writeConfig();
+                break;
             }
           }
         }
@@ -189,6 +194,14 @@ export default class Server extends CommonServer {
   private getJarFile(): string {
     const files = fs.readdirSync(this.getPath());
     return files.find((file) => file.endsWith(".jar"));
+  }
+
+  /**
+   * Returns the first jar file in the server directory.
+   * @private
+   */
+  private getJavaPath(): string {
+    return this.config.javaPath;
   }
 
   /**
@@ -270,7 +283,7 @@ export default class Server extends CommonServer {
       ? "umask 0000 && "
       : "";
     this.proc = spawn(
-      permissionPrefix + "java",
+      permissionPrefix + this.javaPath + "/bin/java",
       this.flags.concat(["-jar", this.getJarFile(), "nogui"]),
       {
         cwd: this.getPath(),
@@ -385,6 +398,22 @@ export default class Server extends CommonServer {
   set autostart(value: boolean) {
     super.autostart = value;
     this.config.autostart = value;
+  }
+
+  /**
+   * Returns {@link #_javaPath}.
+   */
+  get javaPath(): string | null {
+    return this.config.javaPath;
+  }
+
+  /**
+   * Sets a new value for {@link #_javaPath}.
+   * @param value the new value.
+   */
+  set javaPath(value: string | null) {
+    super.javaPath = value;
+    this.config.javaPath = value;
   }
 
   /**

--- a/backend/src/components/server_config.ts
+++ b/backend/src/components/server_config.ts
@@ -16,6 +16,9 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { getDefaultRuntime } from "../../../common/components/java_runtime";
+import { getJavaRuntimes } from "./java_runtime";
+
 /**
  * A class that represents the config file of a server.
  */
@@ -31,12 +34,23 @@ export default class ServerConfig {
   public autostart: boolean;
 
   /**
+   * The path to the java runtime used to run the server.
+   */
+  public javaPath: string;
+
+  /**
    * Creates a new {@link ServerConfig}
    * @param flags the flags of the server, default = `[]`
    * @param autostart whether or not the server should start with the backend.
+   * @param javaPath the path to the java runtime used to run the server.
    */
-  constructor(flags: string[] = [], autostart = false) {
+  constructor(
+    flags: string[] = [],
+    autostart = false,
+    javaPath: string = getDefaultRuntime(getJavaRuntimes()).path
+  ) {
     this.flags = flags;
     this.autostart = autostart;
+    this.javaPath = javaPath;
   }
 }

--- a/common/components/java_runtime.ts
+++ b/common/components/java_runtime.ts
@@ -1,0 +1,108 @@
+/*
+blockcluster - An in-browser manager for your minecraft servers.
+Copyright (C) 2021 jojomatik
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * A representation of a java runtime.
+ */
+export default class JavaRuntime {
+  /**
+   * Creates an instance of {@link JavaRuntime} based on its path and name.
+   * @param path the path to the java runtime.
+   * @param name the name of the java runtime/ its version descriptor.
+   * @param isDefault whether the java runtime is the default runtime.
+   */
+  constructor(path = "", name = "", isDefault = false) {
+    this._path = path;
+    this._name = name;
+    this._isDefault = isDefault;
+  }
+
+  /**
+   * The path to the java runtime.
+   * @private
+   */
+  private _path: string;
+
+  /**
+   * Returns {@link #_path}.
+   */
+  get path(): string {
+    return this._path;
+  }
+
+  /**
+   * Sets a new value for {@link #_path}.
+   * @param value the new value.
+   */
+  set path(value: string) {
+    this._path = value;
+  }
+
+  /**
+   * The name of the java runtime/ its version descriptor.
+   * @private
+   */
+  private _name: string;
+
+  /**
+   * Returns {@link #_name}.
+   */
+  get name(): string {
+    return this._name;
+  }
+
+  /**
+   * Sets a new value for {@link #_name}.
+   * @param value the new value.
+   */
+  set name(value: string) {
+    this._name = value;
+  }
+
+  /**
+   * Whether the java runtime is the default runtime.
+   * @private
+   */
+  private _isDefault: boolean;
+
+  /**
+   * Returns {@link #_isDefault}.
+   */
+  get isDefault(): boolean {
+    return this._isDefault;
+  }
+
+  /**
+   * Sets a new value for {@link #_isDefault}.
+   * @param value the new value.
+   */
+  set isDefault(value: boolean) {
+    this._isDefault = value;
+  }
+}
+
+/**
+ * Returns the default runtime from a list of multiple {@link JavaRuntime}s.
+ * @param runtimes the default runtime.
+ */
+export function getDefaultRuntime(runtimes: JavaRuntime[]): JavaRuntime {
+  for (const runtime of runtimes) {
+    if (runtime.isDefault) return runtime;
+  }
+  throw new Error("No default runtime found.");
+}

--- a/common/components/server.ts
+++ b/common/components/server.ts
@@ -46,6 +46,7 @@ export default class Server {
    * @param world the main world of the server.
    * @param jar the jar file of the server.
    * @param autostart whether the server should start with the backend.
+   * @param javaPath the path to the java runtime used to run the server.
    */
   constructor(
     name = "",
@@ -53,7 +54,8 @@ export default class Server {
     port = 0,
     world = "",
     jar: string | null = null,
-    autostart = false
+    autostart = false,
+    javaPath: string | null = null
   ) {
     this._name = name;
     this._status = status;
@@ -61,6 +63,7 @@ export default class Server {
     this._world = world;
     this._jar = jar;
     this._autostart = autostart;
+    this._javaPath = javaPath;
   }
 
   /**
@@ -208,6 +211,27 @@ export default class Server {
    */
   set autostart(value: boolean) {
     this._autostart = value;
+  }
+
+  /**
+   * The path to the java runtime.
+   * @private
+   */
+  private _javaPath: string | null;
+
+  /**
+   * Returns {@link #_javaPath}.
+   */
+  get javaPath(): string | null {
+    return this._javaPath;
+  }
+
+  /**
+   * Sets a new value for {@link #_javaPath}.
+   * @param value the new value.
+   */
+  set javaPath(value: string | null) {
+    this._javaPath = value;
   }
 
   /**


### PR DESCRIPTION
Allows multiple java runtimes to be installed and the selection of a specific runtime in the frontend.

Includes the LTS versions 11 and 17 of java, which are capable to run the vast majority of minecraft servers. Spigot 1.17 servers strictly require java 16 and are therefore not going to run (vanilla servers of all versions should be able to run on java 17 though). For more details and instructions to use custom java runtimes see #150.

The frontend receives a list of all available java runtimes from the backend as well as the currently selected or default runtime for the current server. The user is able to select another runtime. This information is stored in the `blockcluster.cfg` file in the respective server directory and persisted over restarts of blockcluster. The selected runtime is then used to start the respective server's jar when requested.

Closes #150