### PR TITLE
ci: automatically update `updates` branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,3 +176,17 @@ jobs:
           git_committer_name: ${{ secrets.BUMP_GIT_NAME }}
           git_committer_email: ${{ secrets.BUMP_GIT_EMAIL }}
           github_token: ${{ secrets.GH_TOKEN }}
+  sync_beta_to_updates:
+    if: ${{ github.ref == 'refs/heads/beta' }}
+    name: Sync branch `beta` to `updates` (fast-forward enabled)
+    runs-on: ubuntu-latest
+    needs:
+      - semantic-release
+    steps:
+      - name: Keep `updates` up to date with `beta` (fast-forward enabled)
+        uses: jojomatik/sync-branch@v1
+        with:
+          target: "updates"
+          git_committer_name: ${{ secrets.BUMP_GIT_NAME }}
+          git_committer_email: ${{ secrets.BUMP_GIT_EMAIL }}
+          github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/reset_updates.yml
+++ b/.github/workflows/reset_updates.yml
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    branches:
+      - beta
+    types: [closed]
+
+jobs:
+  reset_updates:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'updates'
+    name: Force push branch `beta` to `updates`
+    runs-on: ubuntu-latest
+    needs:
+      - semantic-release
+    steps:
+      - name: Force push branch `beta` to `updates`
+        uses: jojomatik/sync-branch@v1
+        with:
+          source: 'beta'
+          target: 'updates'
+          strategy: 'force'
+          github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Sync `beta` to `updates` on each push to `beta`. Force-push `updates` as soon as it's merged into `beta` to keep its history linear.