### PR TITLE
feat: add option to pause servers on idle 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.0.0",
         "dotenv-expand": "^8.0.3",
         "express": "^4.17.3",
+        "minecraft-protocol": "^1.30.0",
         "minecraft-server-util": "^5.2.9",
         "pidusage": "^3.0.0",
         "pixelheads": "^1.0.6",
@@ -27,6 +28,60 @@
         "@types/properties-reader": "^2.1.1",
         "@types/uuid": "^8.3.4",
         "nodemon": "^2.0.15"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.0.0.tgz",
+      "integrity": "sha512-Vva3snqmWPHJNDCBb4lz3D0rvZsi/0QikAxHvVFNwtNg5pP4NZE4U34tNiXN+m9KhlQFrZBPkE5rk7dIEOGcWw==",
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@azure/msal-common/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.5.0.tgz",
+      "integrity": "sha512-FiCra/3ZyLXSQltoI9ndeN/lvXsPsFDsqVKgH7SWXVQjL3OpEXiqKkj0CB2UWGCk1U6bZGMJfkUZCXzhMQTObQ==",
+      "dependencies": {
+        "@azure/msal-common": "^6.0.0",
+        "axios": "^0.21.4",
+        "jsonwebtoken": "^8.5.1",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": "10 || 12 || 14 || 16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -164,6 +219,28 @@
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
+    "node_modules/@xboxreplay/errors": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@xboxreplay/errors/-/errors-0.1.0.tgz",
+      "integrity": "sha512-Tgz1d/OIPDWPeyOvuL5+aai5VCcqObhPnlI3skQuf80GVF3k1I0lPCnGC+8Cm5PV9aLBT5m8qPcJoIUQ2U4y9g=="
+    },
+    "node_modules/@xboxreplay/xboxlive-auth": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@xboxreplay/xboxlive-auth/-/xboxlive-auth-3.3.3.tgz",
+      "integrity": "sha512-j0AU8pW10LM8O68CTZ5QHnvOjSsnPICy0oQcP7zyM7eWkDQ/InkiQiirQKsPn1XRYDl4ccNu0WM582s3UKwcBg==",
+      "dependencies": {
+        "@xboxreplay/errors": "^0.1.0",
+        "axios": "^0.21.1"
+      }
+    },
+    "node_modules/@xboxreplay/xboxlive-auth/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -180,6 +257,26 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-align": {
@@ -245,6 +342,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "node_modules/asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "node_modules/axios": {
       "version": "0.26.1",
@@ -413,6 +515,19 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -801,6 +916,14 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -826,6 +949,11 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/endian-toggle": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/endian-toggle/-/endian-toggle-0.0.0.tgz",
+      "integrity": "sha1-5cx1eLEDLW7gHq/Nc3ZdsNtNwKY="
     },
     "node_modules/engine.io": {
       "version": "6.1.1",
@@ -948,6 +1076,16 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -1412,11 +1550,69 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "node_modules/jose": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.4.0.tgz",
+      "integrity": "sha512-3CsqCQWuEUPpNlSLRcLRC8eO/ATFe1tLJMZCtjx2+ma1gkjGQ62HF50oWs3cwtWjLCpM8bdMPpQbxpgc3fhxrQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -1439,6 +1635,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "node_modules/lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -1458,6 +1704,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/macaddress": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.5.2.tgz",
+      "integrity": "sha512-cYYBbT3b84hTEHssWE6OmsuqF/NiLXE2RGK9Sc9SwwE9kMoKrbaUAJtKs6ucd0FFgZjXE1Wm3hoGEEYas0N6EA=="
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -1543,10 +1794,80 @@
         "node": ">=4"
       }
     },
+    "node_modules/minecraft-data": {
+      "version": "2.112.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.112.0.tgz",
+      "integrity": "sha512-BejjohaRRyJKHmvD32x5tn7qsl4fn4tUHeTjlOL6kcZmiFaoD6ARJ1TCWba1ogfekO4H+3toD3QAmNp7iz3Lqw=="
+    },
+    "node_modules/minecraft-folder-path": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minecraft-folder-path/-/minecraft-folder-path-1.2.0.tgz",
+      "integrity": "sha512-qaUSbKWoOsH9brn0JQuBhxNAzTDMwrOXorwuRxdJKKKDYvZhtml+6GVCUrY5HRiEsieBEjCUnhVpDuQiKsiFaw=="
+    },
     "node_modules/minecraft-motd-util": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/minecraft-motd-util/-/minecraft-motd-util-1.1.12.tgz",
       "integrity": "sha512-5TuTRjrRupSTruea0nRC37r0FdhkS1O4wIJKAYfwJRCQd/X4Zyl/dVIs96h9UVW6N8jhIuz9pNkrDsqyN7VBdA=="
+    },
+    "node_modules/minecraft-protocol": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.30.0.tgz",
+      "integrity": "sha512-Zi/TAYyLQrGV8HjBAs2z4DnusezcVdgxEVZH0cxilOElI/xJuPZ7fwXhixHPvyJnuK3RPyCvwOUjhHX27tGcoA==",
+      "dependencies": {
+        "aes-js": "^3.1.2",
+        "buffer-equal": "^1.0.0",
+        "debug": "^4.3.2",
+        "endian-toggle": "^0.0.0",
+        "lodash.get": "^4.1.2",
+        "lodash.merge": "^4.3.0",
+        "minecraft-data": "^2.98.0",
+        "minecraft-folder-path": "^1.2.0",
+        "node-fetch": "^2.6.1",
+        "node-rsa": "^0.4.2",
+        "prismarine-auth": "^1.1.0",
+        "prismarine-nbt": "^2.0.0",
+        "protodef": "^1.8.0",
+        "readable-stream": "^3.0.6",
+        "uuid-1345": "^1.0.1",
+        "yggdrasil": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minecraft-protocol/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minecraft-protocol/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/minecraft-protocol/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/minecraft-server-util": {
       "version": "5.2.9",
@@ -1639,6 +1960,33 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-rsa": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
+      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=",
+      "dependencies": {
+        "asn1": "0.2.3"
+      }
     },
     "node_modules/nodemon": {
       "version": "2.0.15",
@@ -1876,6 +2224,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/prismarine-auth": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prismarine-auth/-/prismarine-auth-1.4.1.tgz",
+      "integrity": "sha512-IyFz+TWkngtRPs19MWP/7dYU1vheiASoil5d7amvIXhbK4zWb/w7uGcwLvOO0fwX9qw5hCt/JKimPrRcw8La0w==",
+      "dependencies": {
+        "@azure/msal-node": "^1.1.0",
+        "@xboxreplay/xboxlive-auth": "^3.3.3",
+        "jose": "^4.1.4",
+        "node-fetch": "^2.6.1",
+        "smart-buffer": "^4.1.0",
+        "uuid-1345": "^1.0.2"
+      }
+    },
+    "node_modules/prismarine-nbt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+      "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+      "dependencies": {
+        "protodef": "^1.9.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -1890,6 +2259,44 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/protodef": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/protodef/-/protodef-1.14.0.tgz",
+      "integrity": "sha512-rL1WRlBC8LbAgBTa401eHMqnkX6zy1pHgS4kTSJVJ8rwP/AgVuWijGE3S3XHRkRjB/+4U1jMTqRdmtGdIqVOKQ==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.reduce": "^4.6.0",
+        "protodef-validator": "^1.3.0",
+        "readable-stream": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/protodef-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/protodef-validator/-/protodef-validator-1.3.1.tgz",
+      "integrity": "sha512-lZ5FWKZYR9xOjpMw1+EfZRfCjzNRQWPq+Dk+jki47Sikl2EeWEPnTfnJERwnU/EwFq6us+0zqHHzSsmLeYX+Lg==",
+      "dependencies": {
+        "ajv": "^6.5.4"
+      },
+      "bin": {
+        "protodef-validator": "cli.js"
+      }
+    },
+    "node_modules/protodef/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/proxy-addr": {
@@ -1917,6 +2324,14 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pupa": {
@@ -2075,7 +2490,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -2268,6 +2682,15 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/socket.io": {
@@ -2491,6 +2914,11 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2604,6 +3032,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -2637,12 +3073,34 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uuid-1345": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-1.0.2.tgz",
+      "integrity": "sha512-bA5zYZui+3nwAc0s3VdGQGBfbVsJLVX7Np7ch2aqcEWFi5lsAEcmO3+lx3djM1npgpZI8KY2FITZ2uYTnYUYyw==",
+      "dependencies": {
+        "macaddress": "^0.5.1"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wide-align": {
@@ -2732,9 +3190,62 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yggdrasil": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yggdrasil/-/yggdrasil-1.6.1.tgz",
+      "integrity": "sha512-6rUJ0A7YNVNd1K+8EvmVUc+l8CbhW7VKnN747BrC+YCukZj9C5rNsGxIZGf4MwxMHFDy/YNY++Gqf0VUxKy2ww==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "uuid": "^8.2.0"
+      }
     }
   },
   "dependencies": {
+    "@azure/msal-common": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.0.0.tgz",
+      "integrity": "sha512-Vva3snqmWPHJNDCBb4lz3D0rvZsi/0QikAxHvVFNwtNg5pP4NZE4U34tNiXN+m9KhlQFrZBPkE5rk7dIEOGcWw==",
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@azure/msal-node": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.5.0.tgz",
+      "integrity": "sha512-FiCra/3ZyLXSQltoI9ndeN/lvXsPsFDsqVKgH7SWXVQjL3OpEXiqKkj0CB2UWGCk1U6bZGMJfkUZCXzhMQTObQ==",
+      "requires": {
+        "@azure/msal-common": "^6.0.0",
+        "axios": "^0.21.4",
+        "jsonwebtoken": "^8.5.1",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2864,6 +3375,30 @@
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
+    "@xboxreplay/errors": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@xboxreplay/errors/-/errors-0.1.0.tgz",
+      "integrity": "sha512-Tgz1d/OIPDWPeyOvuL5+aai5VCcqObhPnlI3skQuf80GVF3k1I0lPCnGC+8Cm5PV9aLBT5m8qPcJoIUQ2U4y9g=="
+    },
+    "@xboxreplay/xboxlive-auth": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@xboxreplay/xboxlive-auth/-/xboxlive-auth-3.3.3.tgz",
+      "integrity": "sha512-j0AU8pW10LM8O68CTZ5QHnvOjSsnPICy0oQcP7zyM7eWkDQ/InkiQiirQKsPn1XRYDl4ccNu0WM582s3UKwcBg==",
+      "requires": {
+        "@xboxreplay/errors": "^0.1.0",
+        "axios": "^0.21.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2877,6 +3412,22 @@
       "requires": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
+      }
+    },
+    "aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-align": {
@@ -2930,6 +3481,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "axios": {
       "version": "0.26.1",
@@ -3048,6 +3604,16 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bytes": {
       "version": "3.1.2",
@@ -3348,6 +3914,14 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3370,6 +3944,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "endian-toggle": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/endian-toggle/-/endian-toggle-0.0.0.tgz",
+      "integrity": "sha1-5cx1eLEDLW7gHq/Nc3ZdsNtNwKY="
     },
     "engine.io": {
       "version": "6.1.1",
@@ -3468,6 +4047,16 @@
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -3800,11 +4389,64 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "jose": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.4.0.tgz",
+      "integrity": "sha512-3CsqCQWuEUPpNlSLRcLRC8eO/ATFe1tLJMZCtjx2+ma1gkjGQ62HF50oWs3cwtWjLCpM8bdMPpQbxpgc3fhxrQ=="
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "keyv": {
       "version": "3.1.0",
@@ -3824,6 +4466,56 @@
         "package-json": "^6.3.0"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -3837,6 +4529,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "macaddress": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.5.2.tgz",
+      "integrity": "sha512-cYYBbT3b84hTEHssWE6OmsuqF/NiLXE2RGK9Sc9SwwE9kMoKrbaUAJtKs6ucd0FFgZjXE1Wm3hoGEEYas0N6EA=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -3894,10 +4591,68 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "minecraft-data": {
+      "version": "2.112.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.112.0.tgz",
+      "integrity": "sha512-BejjohaRRyJKHmvD32x5tn7qsl4fn4tUHeTjlOL6kcZmiFaoD6ARJ1TCWba1ogfekO4H+3toD3QAmNp7iz3Lqw=="
+    },
+    "minecraft-folder-path": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minecraft-folder-path/-/minecraft-folder-path-1.2.0.tgz",
+      "integrity": "sha512-qaUSbKWoOsH9brn0JQuBhxNAzTDMwrOXorwuRxdJKKKDYvZhtml+6GVCUrY5HRiEsieBEjCUnhVpDuQiKsiFaw=="
+    },
     "minecraft-motd-util": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/minecraft-motd-util/-/minecraft-motd-util-1.1.12.tgz",
       "integrity": "sha512-5TuTRjrRupSTruea0nRC37r0FdhkS1O4wIJKAYfwJRCQd/X4Zyl/dVIs96h9UVW6N8jhIuz9pNkrDsqyN7VBdA=="
+    },
+    "minecraft-protocol": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.30.0.tgz",
+      "integrity": "sha512-Zi/TAYyLQrGV8HjBAs2z4DnusezcVdgxEVZH0cxilOElI/xJuPZ7fwXhixHPvyJnuK3RPyCvwOUjhHX27tGcoA==",
+      "requires": {
+        "aes-js": "^3.1.2",
+        "buffer-equal": "^1.0.0",
+        "debug": "^4.3.2",
+        "endian-toggle": "^0.0.0",
+        "lodash.get": "^4.1.2",
+        "lodash.merge": "^4.3.0",
+        "minecraft-data": "^2.98.0",
+        "minecraft-folder-path": "^1.2.0",
+        "node-fetch": "^2.6.1",
+        "node-rsa": "^0.4.2",
+        "prismarine-auth": "^1.1.0",
+        "prismarine-nbt": "^2.0.0",
+        "protodef": "^1.8.0",
+        "readable-stream": "^3.0.6",
+        "uuid-1345": "^1.0.1",
+        "yggdrasil": "^1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "minecraft-server-util": {
       "version": "5.2.9",
@@ -3968,6 +4723,22 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-rsa": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
+      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=",
+      "requires": {
+        "asn1": "0.2.3"
+      }
     },
     "nodemon": {
       "version": "2.0.15",
@@ -4147,6 +4918,27 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
+    "prismarine-auth": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prismarine-auth/-/prismarine-auth-1.4.1.tgz",
+      "integrity": "sha512-IyFz+TWkngtRPs19MWP/7dYU1vheiASoil5d7amvIXhbK4zWb/w7uGcwLvOO0fwX9qw5hCt/JKimPrRcw8La0w==",
+      "requires": {
+        "@azure/msal-node": "^1.1.0",
+        "@xboxreplay/xboxlive-auth": "^3.3.3",
+        "jose": "^4.1.4",
+        "node-fetch": "^2.6.1",
+        "smart-buffer": "^4.1.0",
+        "uuid-1345": "^1.0.2"
+      }
+    },
+    "prismarine-nbt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.2.0.tgz",
+      "integrity": "sha512-6UgW9gkurSs2+L6el6bVHvK5BmfAdMv9ixY+zn4GSaTSOzuWumspErpStxo9RbeixmVq66dd0OQu1tHYXVkX8g==",
+      "requires": {
+        "protodef": "^1.9.0"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4158,6 +4950,37 @@
       "integrity": "sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==",
       "requires": {
         "mkdirp": "^1.0.4"
+      }
+    },
+    "protodef": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/protodef/-/protodef-1.14.0.tgz",
+      "integrity": "sha512-rL1WRlBC8LbAgBTa401eHMqnkX6zy1pHgS4kTSJVJ8rwP/AgVuWijGE3S3XHRkRjB/+4U1jMTqRdmtGdIqVOKQ==",
+      "requires": {
+        "lodash.get": "^4.4.2",
+        "lodash.reduce": "^4.6.0",
+        "protodef-validator": "^1.3.0",
+        "readable-stream": "^3.0.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "protodef-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/protodef-validator/-/protodef-validator-1.3.1.tgz",
+      "integrity": "sha512-lZ5FWKZYR9xOjpMw1+EfZRfCjzNRQWPq+Dk+jki47Sikl2EeWEPnTfnJERwnU/EwFq6us+0zqHHzSsmLeYX+Lg==",
+      "requires": {
+        "ajv": "^6.5.4"
       }
     },
     "proxy-addr": {
@@ -4183,6 +5006,11 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -4302,8 +5130,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -4437,6 +5264,11 @@
       "requires": {
         "is-arrayish": "^0.3.1"
       }
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socket.io": {
       "version": "4.4.1",
@@ -4612,6 +5444,11 @@
         "nopt": "~1.0.10"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4697,6 +5534,14 @@
         }
       }
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -4721,10 +5566,32 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
+    "uuid-1345": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-1.0.2.tgz",
+      "integrity": "sha512-bA5zYZui+3nwAc0s3VdGQGBfbVsJLVX7Np7ch2aqcEWFi5lsAEcmO3+lx3djM1npgpZI8KY2FITZ2uYTnYUYyw==",
+      "requires": {
+        "macaddress": "^0.5.1"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "wide-align": {
       "version": "1.1.5",
@@ -4787,6 +5654,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yggdrasil": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yggdrasil/-/yggdrasil-1.6.1.tgz",
+      "integrity": "sha512-6rUJ0A7YNVNd1K+8EvmVUc+l8CbhW7VKnN747BrC+YCukZj9C5rNsGxIZGf4MwxMHFDy/YNY++Gqf0VUxKy2ww==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "uuid": "^8.2.0"
+      }
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^16.0.0",
     "dotenv-expand": "^8.0.3",
     "express": "^4.17.3",
+    "minecraft-protocol": "^1.30.0",
     "minecraft-server-util": "^5.2.9",
     "pidusage": "^3.0.0",
     "pixelheads": "^1.0.6",

--- a/backend/src/backend.ts
+++ b/backend/src/backend.ts
@@ -33,6 +33,10 @@ dotenvExpand.expand(dotenv.config({ path: "../.env.local" }));
 import { getVersion } from "../../common/version";
 import { getJavaRuntimes } from "./components/java_runtime";
 import getDependencyInfo from "./utils/dependency_info";
+import {
+  ServerPropertiesFile,
+  getPropertiesFromFile,
+} from "../../common/components/server_properties";
 
 const app = express();
 
@@ -111,10 +115,15 @@ async function getServers(): Promise<Server[]> {
     const path = basePath + "/" + file;
     const isDir: boolean = fs.lstatSync(path).isDirectory();
     if (isDir && fs.readdirSync(path).includes(propertiesFile)) {
-      const properties = PropertiesReader(path + "/" + propertiesFile);
-      const port = Number.parseInt(properties.get("server-port") as string);
-      const world = properties.get("level-name") as string;
-      const server = new Server({ _name: file, _port: port, _world: world });
+      const properties = getPropertiesFromFile(
+        PropertiesReader(
+          path + "/" + propertiesFile
+        ).getAllProperties() as ServerPropertiesFile
+      );
+      const server = new Server({
+        _name: file,
+        _properties: properties,
+      });
       servers.push(server);
     }
   }

--- a/backend/src/backend.ts
+++ b/backend/src/backend.ts
@@ -114,7 +114,7 @@ async function getServers(): Promise<Server[]> {
       const properties = PropertiesReader(path + "/" + propertiesFile);
       const port = Number.parseInt(properties.get("server-port") as string);
       const world = properties.get("level-name") as string;
-      const server = new Server(file, ServerStatus.Unknown, port, world);
+      const server = new Server({ _name: file, _port: port, _world: world });
       servers.push(server);
     }
   }

--- a/backend/src/components/server.ts
+++ b/backend/src/components/server.ts
@@ -159,7 +159,7 @@ export default class Server extends CommonServer {
             this.status = ServerStatus.Stopping;
             break;
         }
-        this.proc.stdin.write(commandArr[2] + "\n");
+        this.writeConsoleCommand(commandArr[2]);
         break;
       case "getMessages":
         await this.sendConsoleMessage(this.messages, false);
@@ -388,6 +388,15 @@ export default class Server extends CommonServer {
         }, 4500);
       }, 500);
     }
+  }
+
+  /**
+   * Writes a command to `stdin` of the current process.
+   * @param command the command to send.
+   * @private
+   */
+  private writeConsoleCommand(command: string) {
+    this.proc.stdin.write(command + "\n");
   }
 
   /**

--- a/backend/src/components/server_config.ts
+++ b/backend/src/components/server_config.ts
@@ -18,6 +18,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import { getDefaultRuntime } from "../../../common/components/java_runtime";
 import { getJavaRuntimes } from "./java_runtime";
+import { PauseOnIdleType } from "../../../common/components/server";
 
 /**
  * A class that represents the config file of a server.
@@ -34,6 +35,11 @@ export default class ServerConfig {
   public autostart: boolean;
 
   /**
+   * Whether the server should pause on idle (i.e. with no players) or not.
+   */
+  public pauseOnIdle: PauseOnIdleType;
+
+  /**
    * The path to the java runtime used to run the server.
    */
   public javaPath: string;
@@ -42,15 +48,21 @@ export default class ServerConfig {
    * Creates a new {@link ServerConfig}
    * @param flags the flags of the server, default = `[]`
    * @param autostart whether the server should start with the backend or not.
+   * @param pauseOnIdle whether the server should pause on idle (i.e. with no players) or not.
    * @param javaPath the path to the java runtime used to run the server.
    */
   constructor(
     flags: string[] = [],
     autostart = false,
+    pauseOnIdle = {
+      enable: false,
+      timeout: 300,
+    },
     javaPath: string = getDefaultRuntime(getJavaRuntimes()).path
   ) {
     this.flags = flags;
     this.autostart = autostart;
+    this.pauseOnIdle = pauseOnIdle;
     this.javaPath = javaPath;
   }
 }

--- a/backend/src/components/server_config.ts
+++ b/backend/src/components/server_config.ts
@@ -29,7 +29,7 @@ export default class ServerConfig {
   public flags: string[];
 
   /**
-   * Whether or not the server should start with the backend.
+   * Whether the server should start with the backend or not.
    */
   public autostart: boolean;
 
@@ -41,7 +41,7 @@ export default class ServerConfig {
   /**
    * Creates a new {@link ServerConfig}
    * @param flags the flags of the server, default = `[]`
-   * @param autostart whether or not the server should start with the backend.
+   * @param autostart whether the server should start with the backend or not.
    * @param javaPath the path to the java runtime used to run the server.
    */
   constructor(

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,7 +13,10 @@
         "node_modules/",
         "src/types/*"
       ]
-    }
+    },
+    "lib": [
+      "ES2021.String"
+    ]
   },
   "include": [
     "src/**/*"

--- a/common/components/message.ts
+++ b/common/components/message.ts
@@ -24,6 +24,7 @@ import { v4 as uuid } from "uuid";
 export enum MessageType {
   Default,
   Error,
+  Blockcluster,
   DateChange,
 }
 

--- a/common/components/server.ts
+++ b/common/components/server.ts
@@ -18,6 +18,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import ResourceUsage from "./resource_usage";
 import Player from "./player";
+import { ServerProperties } from "./server_properties";
 
 /**
  * An enum that holds different states a {@link Server} can be in.
@@ -44,8 +45,9 @@ export default class Server {
    * @param data the data that shoudl be usd to create the {@link Server}:
    *    name: the name of the server.
    *    status: the status of the server.
-   *    port: the port the server listens on.
-   *    world: the main world of the server.
+   *    properties: the properties of the server:
+   *      port: the port the server listens on.
+   *      world: the main world of the server.
    *    favicon: the favicon of the server.
    *    jar: the jar file of the server.
    *    autostart: whether the server should start with the backend.
@@ -55,8 +57,22 @@ export default class Server {
   constructor(data: ServerType) {
     this._name = data._name || "";
     this._status = data._status || ServerStatus.Unknown;
-    this._port = data._port || 0;
-    this._world = data._world || "";
+    this._properties = data._properties || {
+      serverPort: 0,
+      levelName: "",
+      spawnProtection: 0,
+      whiteList: false,
+      hardcore: false,
+      allowNether: false,
+      viewDistance: 0,
+      onlineMode: false,
+      maxPlayers: 0,
+      difficulty: "peaceful",
+      motd: "",
+      levelSeed: "",
+      pvp: false,
+      gamemode: "survival",
+    };
     this._favicon = data._favicon || "";
     this._jar = data._jar || null;
     this._autostart = data._autostart || false;
@@ -112,45 +128,54 @@ export default class Server {
   }
 
   /**
-   * The port that the {@link Server} listens to.
+   * The properties of this {@link Server}.
    * @private
    */
-  private _port: number;
+  private _properties: ServerProperties;
 
   /**
-   * Returns {@link #port}.
+   * Returns {@link #_properties}.
    */
-  get port(): number {
-    return this._port;
+  get properties(): ServerProperties {
+    return this._properties;
   }
 
   /**
-   * Sets a new value for {@link #port}.
+   * Sets a new value for {@link #_properties}.
+   * @private
+   */
+  set properties(value: ServerProperties) {
+    this._properties = value;
+  }
+
+  /**
+   * Returns the port of this {@link Server}.
+   */
+  get port(): number {
+    return this.properties.serverPort;
+  }
+
+  /**
+   * Sets a new port for this {@link Server}.
    * @private
    */
   set port(value: number) {
-    this._port = value;
+    this.properties.serverPort = value;
   }
 
   /**
-   * The name of the world of the {@link Server}.
-   * @private
-   */
-  private _world: string;
-
-  /**
-   * Returns {@link #world}.
+   Returns the world of this {@link Server}.
    */
   get world(): string {
-    return this._world;
+    return this.properties.levelName;
   }
 
   /**
-   * Sets a new value for {@link #world}.
+   Sets a new world for this {@link Server}.
    * @param value the new value.
    */
   set world(value: string) {
-    this._world = value;
+    this.properties.levelName = value;
   }
 
   /**
@@ -380,14 +405,9 @@ type ServerType = {
   _status?: ServerStatus;
 
   /**
-   * The port of this {@link ServerType}
+   * The properties of this {@link ServerType}
    */
-  _port?: number;
-
-  /**
-   * The world of this {@link ServerType}
-   */
-  _world?: string;
+  _properties?: ServerProperties;
 
   /**
    * The favicon of this {@link ServerType}

--- a/common/components/server.ts
+++ b/common/components/server.ts
@@ -29,6 +29,7 @@ export enum ServerStatus {
   Starting,
   Started,
   Stopping,
+  Paused,
 }
 
 /**
@@ -51,6 +52,7 @@ export default class Server {
    *    favicon: the favicon of the server.
    *    jar: the jar file of the server.
    *    autostart: whether the server should start with the backend.
+   *    pauseOnIdle: whether the server pause on idle (i.e. with no players).
    *    javaPath: the path to the java runtime used to run the server.
    *    players: the players stats and a sample of players online.
    */
@@ -76,6 +78,7 @@ export default class Server {
     this._favicon = data._favicon || "";
     this._jar = data._jar || null;
     this._autostart = data._autostart || false;
+    this._pauseOnIdle = data._pauseOnIdle || { enable: false, timeout: 300 };
     this._javaPath = data._javaPath || null;
     this._players = data._players || {
       online: 0,
@@ -263,6 +266,27 @@ export default class Server {
   }
 
   /**
+   * Whether the server should pause if it is idling (i.e. no players are online) and which timeout is used.
+   * @private
+   */
+  private _pauseOnIdle: PauseOnIdleType;
+
+  /**
+   * Returns {@link #_pauseOnIdle}.
+   */
+  get pauseOnIdle(): PauseOnIdleType {
+    return this._pauseOnIdle;
+  }
+
+  /**
+   * Sets a new value for {@link #_pauseOnIdle}.
+   * @param value the new value.
+   */
+  set pauseOnIdle(value: PauseOnIdleType) {
+    this._pauseOnIdle = value;
+  }
+
+  /**
    * The path to the java runtime.
    * @private
    */
@@ -425,6 +449,11 @@ type ServerType = {
   _autostart?: boolean;
 
   /**
+   * The pause-on-idle-property of this {@link ServerType}
+   */
+  _pauseOnIdle?: PauseOnIdleType;
+
+  /**
    * The java path of this {@link ServerType}
    */
   _javaPath?: string;
@@ -438,4 +467,12 @@ type ServerType = {
    * The resource usage of this {@link ServerType}
    */
   _resourceUsage?: ResourceUsage[];
+};
+
+/**
+ * The type of the pause-on-idle property.
+ */
+export type PauseOnIdleType = {
+  enable: boolean;
+  timeout: number;
 };

--- a/common/components/server.ts
+++ b/common/components/server.ts
@@ -23,11 +23,11 @@ import Player from "./player";
  * An enum that holds different states a {@link Server} can be in.
  */
 export enum ServerStatus {
+  Unknown,
   Stopped,
   Starting,
   Started,
   Stopping,
-  Unknown,
 }
 
 /**
@@ -37,44 +37,36 @@ export default class Server {
   /**
    * An frozen instance of {@link Server} with default values.
    */
-  static emptyServer: Readonly<Server> = Object.freeze(new Server());
+  static emptyServer: Readonly<Server> = Object.freeze(new Server({}));
 
   /**
    * Creates an instance of {@link Server} based on its name, its current state and its port.
-   * @param name the name of the server.
-   * @param status the status of the server.
-   * @param port the port the server listens on.
-   * @param world the main world of the server.
-   * @param favicon the favicon of the server.
-   * @param jar the jar file of the server.
-   * @param autostart whether the server should start with the backend.
-   * @param javaPath the path to the java runtime used to run the server.
-   * @param players the players stats and a sample of players online.
+   * @param data the data that shoudl be usd to create the {@link Server}:
+   *    name: the name of the server.
+   *    status: the status of the server.
+   *    port: the port the server listens on.
+   *    world: the main world of the server.
+   *    favicon: the favicon of the server.
+   *    jar: the jar file of the server.
+   *    autostart: whether the server should start with the backend.
+   *    javaPath: the path to the java runtime used to run the server.
+   *    players: the players stats and a sample of players online.
    */
-  constructor(
-    name = "",
-    status: ServerStatus = ServerStatus.Unknown,
-    port = 0,
-    world = "",
-    favicon = "",
-    jar: string | null = null,
-    autostart = false,
-    javaPath: string | null = null,
-    players: playerStats = {
+  constructor(data: ServerType) {
+    this._name = data._name || "";
+    this._status = data._status || ServerStatus.Unknown;
+    this._port = data._port || 0;
+    this._world = data._world || "";
+    this._favicon = data._favicon || "";
+    this._jar = data._jar || null;
+    this._autostart = data._autostart || false;
+    this._javaPath = data._javaPath || null;
+    this._players = data._players || {
       online: 0,
       max: 0,
       sample: [],
-    }
-  ) {
-    this._name = name;
-    this._status = status;
-    this._port = port;
-    this._world = world;
-    this._favicon = favicon;
-    this._jar = jar;
-    this._autostart = autostart;
-    this._javaPath = javaPath;
-    this._players = players;
+    };
+    this._resourceUsage = data._resourceUsage || [];
   }
 
   /**
@@ -320,7 +312,7 @@ export default class Server {
       )
         stripped[key] = this[key];
     }
-    return Object.assign(new Server(), stripped);
+    return Object.assign(new Server({}), stripped);
   }
 
   /**
@@ -371,4 +363,59 @@ export type playerStats = {
   online: number;
   max: number;
   sample: Player[];
+};
+
+/**
+ * A type that contains the properties of a {@link Server}.
+ */
+type ServerType = {
+  /**
+   * The name of this {@link ServerType}
+   */
+  _name?: string;
+
+  /**
+   * The status of this {@link ServerType}
+   */
+  _status?: ServerStatus;
+
+  /**
+   * The port of this {@link ServerType}
+   */
+  _port?: number;
+
+  /**
+   * The world of this {@link ServerType}
+   */
+  _world?: string;
+
+  /**
+   * The favicon of this {@link ServerType}
+   */
+  _favicon?: string;
+
+  /**
+   * The jar of this {@link ServerType}
+   */
+  _jar?: string;
+
+  /**
+   * The autostart-property of this {@link ServerType}
+   */
+  _autostart?: boolean;
+
+  /**
+   * The java path of this {@link ServerType}
+   */
+  _javaPath?: string;
+
+  /**
+   * The player stats of this {@link ServerType}
+   */
+  _players?: playerStats;
+
+  /**
+   * The resource usage of this {@link ServerType}
+   */
+  _resourceUsage?: ResourceUsage[];
 };

--- a/common/components/server_properties.ts
+++ b/common/components/server_properties.ts
@@ -1,0 +1,83 @@
+/*
+blockcluster - An in-browser manager for your minecraft servers.
+Copyright (C) 2021 jojomatik
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * A type that contains a selection of the properties of the `server.properties` file.
+ */
+export type ServerPropertiesFile = {
+  "level-seed": string;
+  gamemode: "survival" | "creative" | "spectator" | "adventure";
+  "level-name": string;
+  motd: string;
+  pvp: string;
+  difficulty: "peaceful" | "easy" | "medium" | "hard";
+  "max-players": string;
+  "online-mode": string;
+  "view-distance": string;
+  "allow-nether": string;
+  "server-port": string;
+  hardcore: string;
+  "white-list": string;
+  "spawn-protection": string;
+};
+
+/**
+ * A type that contains some properties of a {@link Server}.
+ */
+export type ServerProperties = {
+  levelSeed: string;
+  gamemode: "survival" | "creative" | "spectator" | "adventure";
+  levelName: string;
+  motd: string;
+  pvp: boolean;
+  difficulty: "peaceful" | "easy" | "medium" | "hard";
+  maxPlayers: number;
+  onlineMode: boolean;
+  viewDistance: number;
+  allowNether: boolean;
+  serverPort: number;
+  hardcore: boolean;
+  whiteList: boolean;
+  spawnProtection: number;
+};
+
+/**
+ * Returns the properties from the `server.properties` file converted to {@link ServerProperties}.
+ *
+ * @param read the properties from the file
+ */
+export function getPropertiesFromFile(
+  read: ServerPropertiesFile
+): ServerProperties {
+  return {
+    levelSeed: read["level-seed"],
+    gamemode: read.gamemode,
+    levelName: read["level-name"],
+    motd: read.motd,
+    pvp: read.pvp === "true",
+    difficulty: read.difficulty,
+    maxPlayers: Number.parseInt(read["max-players"]),
+    onlineMode: read["online-mode"] === "true",
+    viewDistance: Number.parseInt(read["view-distance"]),
+    allowNether: read["allow-nether"] === "true",
+    serverPort: Number.parseInt(read["server-port"]),
+    hardcore: read.hardcore === "true",
+    whiteList: read["white-list"] === "true",
+    spawnProtection: Number.parseInt(read["spawn-protection"]),
+  };
+}

--- a/src/components/ConsoleComponent.vue
+++ b/src/components/ConsoleComponent.vue
@@ -42,7 +42,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 {{ message.text }}
               </span>
               <span
-                style="color: teal; text-decoration: underline"
+                class="blockcluster-message"
+                style="text-decoration: underline"
                 v-else-if="message.type === MessageType.DateChange"
               >
                 {{ message.text }}
@@ -271,4 +272,8 @@ export default class ConsoleComponent extends Vue {
 }
 </script>
 
-<style scoped></style>
+<style scoped lang="scss">
+.blockcluster-message {
+  color: var(--v-accent-lighten2) !important;
+}
+</style>

--- a/src/components/ConsoleComponent.vue
+++ b/src/components/ConsoleComponent.vue
@@ -48,6 +48,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
               >
                 {{ message.text }}
               </span>
+              <span
+                class="blockcluster-message"
+                v-else-if="message.type === MessageType.Blockcluster"
+              >
+                {{ message.text }}
+              </span>
               <span v-else>{{ message.text }}</span>
             </v-col>
           </v-row>

--- a/src/components/ServerComponent.vue
+++ b/src/components/ServerComponent.vue
@@ -66,6 +66,32 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                       </td>
                     </tr>
                     <tr>
+                      <td>Pause on idle</td>
+                      <td>
+                        <v-switch
+                          class="ma-auto mb-1"
+                          hide-details
+                          color="secondary"
+                          v-bind:value="pauseOnIdle.enable"
+                          @change="setPauseEnabled"
+                        />
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Pause on idle timeout</td>
+                      <td>
+                        <v-text-field
+                          hide-details
+                          dense
+                          single-line
+                          type="number"
+                          v-bind:value="pauseOnIdle.timeout"
+                          @change="setPauseTimeout"
+                        >
+                        </v-text-field>
+                      </td>
+                    </tr>
+                    <tr>
                       <td>Java Runtime</td>
                       <td style="display: flex; flex-direction: row">
                         <v-select
@@ -174,7 +200,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
 
-import Server, { ServerStatus } from "../../common/components/server";
+import Server, {
+  PauseOnIdleType,
+  ServerStatus,
+} from "../../common/components/server";
 import ServerStatusComponent from "@/components/ServerStatusComponent.vue";
 import ConsoleComponent from "@/components/ConsoleComponent.vue";
 import StateChangeButtonComponent from "@/components/StateChangeButtonComponent.vue";
@@ -308,6 +337,42 @@ export default class ServerComponent extends Vue {
   set autostart(value: boolean) {
     this.server.autostart = value;
     this.sendMessage("set " + JSON.stringify({ autostart: value }));
+  }
+
+  /**
+   * Returns the `pauseOnIdle` option of the server.
+   */
+  get pauseOnIdle(): PauseOnIdleType {
+    return this.server.pauseOnIdle;
+  }
+
+  /**
+   * Sets the `pauseOnIdle` option of the server.
+   * @param value the `pauseOnIdle` option to be sent to the server.
+   */
+  set pauseOnIdle(value: PauseOnIdleType) {
+    this.server.pauseOnIdle = value;
+    this.sendMessage("set " + JSON.stringify({ pauseOnIdle: value }));
+  }
+
+  /**
+   * Sets the `enabled` property of the `pauseOnIdle` option of the server.
+   * @param value the `enabled` property of the `pauseOnIdle` option to be sent to the server.
+   */
+  setPauseEnabled(value: boolean | null) {
+    const pauseOnIdle = this.pauseOnIdle;
+    pauseOnIdle.enable = value === true;
+    this.pauseOnIdle = pauseOnIdle;
+  }
+
+  /**
+   * Sets the `timeout` property of the `pauseOnIdle` option of the server.
+   * @param value the `timeout` property of the `pauseOnIdle` option to be sent to the server.
+   */
+  setPauseTimeout(value: string) {
+    const pauseOnIdle = this.pauseOnIdle;
+    pauseOnIdle.timeout = parseInt(value);
+    this.pauseOnIdle = pauseOnIdle;
   }
 
   /**

--- a/src/components/ServerStatusComponent.vue
+++ b/src/components/ServerStatusComponent.vue
@@ -62,6 +62,8 @@ export default class ServerStatusComponent extends Vue {
       case ServerStatus.Starting:
       case ServerStatus.Stopping:
         return "yellow darken-2";
+      case ServerStatus.Paused:
+        return "secondary";
     }
   }
 }

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -22,10 +22,10 @@ import Vuetify from "vuetify/lib/framework";
 Vue.use(Vuetify);
 
 export default new Vuetify({
-  options: {
-    customProperties: true,
-  },
   theme: {
+    options: {
+      customProperties: true,
+    },
     themes: {
       light: {
         primary: "#E1E1E1",

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -79,7 +79,7 @@ export default class Home extends Vue {
     this.sockets.subscribe("MESSAGE", (data: Record<string, unknown>[]) => {
       this.servers = [];
       data.forEach((elem: Record<string, unknown>) => {
-        const server: Server = Object.assign(new Server(), elem);
+        const server: Server = new Server(elem);
         server.players.sample = server.players.sample.map((player) => {
           return Object.assign(new Player(), player);
         });

--- a/src/views/ServerView.vue
+++ b/src/views/ServerView.vue
@@ -25,7 +25,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import ServerComponent from "@/components/ServerComponent.vue"; // @ is an alias to /src
-import Server, { ServerStatus } from "../../common/components/server";
+import Server from "../../common/components/server";
 
 /**
  * A {@link Vue}-View that shows one server.
@@ -43,6 +43,6 @@ export default class ServerView extends Vue {
    * The server shown in this {@ServerView}.
    * @private
    */
-  private server = new Server("", ServerStatus.Unknown, 0);
+  private server = new Server({});
 }
 </script>


### PR DESCRIPTION
Add option to automatically pause servers on idle (i.e. with no players online). Add a timeout that starts if no players are online and stops the server after a configurable amount of time. If a player joins during that time the timeout is cleared and the server won't stop. While a server is paused a mock-server based on `minecraft-protocol` is started and handles connections by clients. It shows the status in the minecraft client server overview and if a player connects the server will start and the player is prompted to reconnect in a few seconds.

This feature can be configured in the frontend or by manually configuring it in `blockcluster.cfg` for each server. By default, this feature is disabled and the timeout is set to 300s.

Changes to the server status and idle timeout are being logged to the server itself as well as the blockcluster frontend.

Closes https://github.com/jojomatik/blockcluster/issues/279