### PR TITLE
fix(backend): don't show incompatible version to client 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^16.0.0",
         "dotenv-expand": "^8.0.3",
         "express": "^4.17.3",
-        "minecraft-protocol": "^1.32.1",
+        "minecraft-protocol": "^1.34.0",
         "minecraft-server-util": "^5.2.9",
         "pidusage": "^3.0.0",
         "pixelheads": "^1.0.6",
@@ -202,6 +202,15 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
+      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "*"
+      }
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
@@ -1795,9 +1804,9 @@
       }
     },
     "node_modules/minecraft-data": {
-      "version": "2.220.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.220.0.tgz",
-      "integrity": "sha512-6/1TxrX9jf8z8aRxWtB9IiDy6O3t6Yor/qGxCDB8ibahf/Ss5HNaPjjjjATLrdT2KrIWywv5oc4eSZ2bfXlDmQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.0.0.tgz",
+      "integrity": "sha512-8gChk4VUYky3XfMRO+YE1eS7OHC7uzEbxuosav7f5P8rewJ/8XNIPTmXYZOWnC2MoYCFwHRNHhwpt2YuxsDYqw=="
     },
     "node_modules/minecraft-folder-path": {
       "version": "1.2.0",
@@ -1810,17 +1819,18 @@
       "integrity": "sha512-5TuTRjrRupSTruea0nRC37r0FdhkS1O4wIJKAYfwJRCQd/X4Zyl/dVIs96h9UVW6N8jhIuz9pNkrDsqyN7VBdA=="
     },
     "node_modules/minecraft-protocol": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.32.1.tgz",
-      "integrity": "sha512-m7FkkkGvFjTdapQgdmXhIeuNwxAofe+PvN1e7wmP6sxyaM/28XqJkTtGA+fD8WfyYaP0ESxNvTb5zxG0aGOvNg==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.34.0.tgz",
+      "integrity": "sha512-YqS0LWz2Fq4iA/HEWmUrlV8arlVSD36yayYryXpeNgv5mCpEeOocO+i0td+bzAqPA5z0RxZT3IbiWAZCYrkvHA==",
       "dependencies": {
+        "@types/readable-stream": "^2.3.13",
         "aes-js": "^3.1.2",
         "buffer-equal": "^1.0.0",
         "debug": "^4.3.2",
         "endian-toggle": "^0.0.0",
         "lodash.get": "^4.1.2",
         "lodash.merge": "^4.3.0",
-        "minecraft-data": "^2.109.0",
+        "minecraft-data": "^3.0.0",
         "minecraft-folder-path": "^1.2.0",
         "node-fetch": "^2.6.1",
         "node-rsa": "^0.4.2",
@@ -3359,6 +3369,15 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "@types/readable-stream": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
+      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "*"
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -4592,9 +4611,9 @@
       "dev": true
     },
     "minecraft-data": {
-      "version": "2.220.0",
-      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.220.0.tgz",
-      "integrity": "sha512-6/1TxrX9jf8z8aRxWtB9IiDy6O3t6Yor/qGxCDB8ibahf/Ss5HNaPjjjjATLrdT2KrIWywv5oc4eSZ2bfXlDmQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.0.0.tgz",
+      "integrity": "sha512-8gChk4VUYky3XfMRO+YE1eS7OHC7uzEbxuosav7f5P8rewJ/8XNIPTmXYZOWnC2MoYCFwHRNHhwpt2YuxsDYqw=="
     },
     "minecraft-folder-path": {
       "version": "1.2.0",
@@ -4607,17 +4626,18 @@
       "integrity": "sha512-5TuTRjrRupSTruea0nRC37r0FdhkS1O4wIJKAYfwJRCQd/X4Zyl/dVIs96h9UVW6N8jhIuz9pNkrDsqyN7VBdA=="
     },
     "minecraft-protocol": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.32.1.tgz",
-      "integrity": "sha512-m7FkkkGvFjTdapQgdmXhIeuNwxAofe+PvN1e7wmP6sxyaM/28XqJkTtGA+fD8WfyYaP0ESxNvTb5zxG0aGOvNg==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.34.0.tgz",
+      "integrity": "sha512-YqS0LWz2Fq4iA/HEWmUrlV8arlVSD36yayYryXpeNgv5mCpEeOocO+i0td+bzAqPA5z0RxZT3IbiWAZCYrkvHA==",
       "requires": {
+        "@types/readable-stream": "^2.3.13",
         "aes-js": "^3.1.2",
         "buffer-equal": "^1.0.0",
         "debug": "^4.3.2",
         "endian-toggle": "^0.0.0",
         "lodash.get": "^4.1.2",
         "lodash.merge": "^4.3.0",
-        "minecraft-data": "^2.109.0",
+        "minecraft-data": "^3.0.0",
         "minecraft-folder-path": "^1.2.0",
         "node-fetch": "^2.6.1",
         "node-rsa": "^0.4.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "dotenv": "^16.0.0",
     "dotenv-expand": "^8.0.3",
     "express": "^4.17.3",
-    "minecraft-protocol": "^1.32.1",
+    "minecraft-protocol": "^1.34.0",
     "minecraft-server-util": "^5.2.9",
     "pidusage": "^3.0.0",
     "pixelheads": "^1.0.6",

--- a/backend/src/components/server.ts
+++ b/backend/src/components/server.ts
@@ -459,6 +459,7 @@ export default class Server extends CommonServer {
         this.properties.motd.replaceAll("\\u00A7", "§"),
       maxPlayers: this.properties.maxPlayers,
       favicon: this.favicon,
+      version: false,
     });
 
     this.wakeUpListener.on("listening", async () => {


### PR DESCRIPTION
Don't show an incompatible version to the minecraft client, if the server is paused and the client uses a version that differs from the current default version in `minecraft-protocol`. An incompatible version was previously shown, even though the version the server might be compatible with the client version.

Requires an updated version `^1.32.2` of `minecraft-protocol` (https://github.com/PrismarineJS/node-minecraft-protocol/pull/976).

